### PR TITLE
ci: remove push trigger from workflows and update release assets

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,8 +1,6 @@
 name: Backend CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,8 +1,6 @@
 name: Frontend CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -1,9 +1,7 @@
 name: Release & Deploy
 
 on:
-  workflow_run:
-    workflows: ["Backend CI", "Frontend CI", "Security Analysis"]
-    types: [completed]
+  push:
     branches: [main]
 
 env:
@@ -18,14 +16,28 @@ jobs:
   check-prerequisites:
     name: Check Prerequisites
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     outputs:
       should_deploy: ${{ steps.check.outputs.should_deploy }}
     steps:
-      - name: Check workflow status
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit message
         id: check
         run: |
-          echo "should_deploy=true" >> $GITHUB_OUTPUT
+          # Get the latest commit message
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          echo "Latest commit message: $COMMIT_MSG"
+
+          # Skip if commit message contains skip patterns or is from release bot
+          if echo "$COMMIT_MSG" | grep -qiE '\[skip ci\]|\[ci skip\]|chore\(release\):'; then
+            echo "Skipping deployment due to commit message"
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          fi
 
   release:
     name: Semantic Release
@@ -80,7 +92,7 @@ jobs:
       packages: write
     env:
       DOCKER_IMAGE_NAME: planora-api
-      DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      DOCKER_REGISTRY: ghcr.io
       RELEASE_VERSION: ${{ needs.release.outputs.version || '1.0.0' }}
     steps:
       - name: Check out code
@@ -88,6 +100,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set registry owner
+        id: registry
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Login to container registry
         uses: docker/login-action@v3
@@ -104,8 +120,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:latest
-            ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
+            ${{ env.DOCKER_REGISTRY }}/${{ steps.registry.outputs.owner }}/${{ env.DOCKER_IMAGE_NAME }}:latest
+            ${{ env.DOCKER_REGISTRY }}/${{ steps.registry.outputs.owner }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
 
   docker-frontend:
     name: Build Frontend Docker Image
@@ -117,7 +133,7 @@ jobs:
       packages: write
     env:
       FRONTEND_IMAGE_NAME: planora-frontend
-      DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      DOCKER_REGISTRY: ghcr.io
       RELEASE_VERSION: ${{ needs.release.outputs.version || '1.0.0' }}
     steps:
       - name: Check out code
@@ -125,6 +141,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set registry owner
+        id: registry
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Login to container registry
         uses: docker/login-action@v3
@@ -141,8 +161,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:latest
-            ${{ env.DOCKER_REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
+            ${{ env.DOCKER_REGISTRY }}/${{ steps.registry.outputs.owner }}/${{ env.FRONTEND_IMAGE_NAME }}:latest
+            ${{ env.DOCKER_REGISTRY }}/${{ steps.registry.outputs.owner }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
 
   deploy:
     name: Deploy to Coolify

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,6 @@
 name: Security Analysis
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   schedule:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -33,7 +33,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
+        "assets": ["client/package.json","package.json", "package-lock.json", "CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
### Workflow Trigger Updates:
* `.github/workflows/backend-ci.yml`, `.github/workflows/frontend-ci.yml`, `.github/workflows/security.yml`: Changed workflow triggers from `push` to `pull_request` for the `main` branch, ensuring workflows run only for pull requests. [[1]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL4-L5) [[2]](diffhunk://#diff-5cd76c2d3da116c3ec33f2a8ce86d739d0fe4e46c0563f2dde614ab8afc41f38L4-L5) [[3]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL4-L5)

### Deployment Process Enhancements:
* [`.github/workflows/release-deploy.yml`](diffhunk://#diff-f65da199da05f3d39cdf917e1a510752d5a423aa3f954cec3787ccbd462b31e7L4-R4): Replaced `workflow_run` trigger with `push` for the `main` branch, added commit message checks to skip deployments for specific patterns, and removed dependency on previous workflow statuses. [[1]](diffhunk://#diff-f65da199da05f3d39cdf917e1a510752d5a423aa3f954cec3787ccbd462b31e7L4-R4) [[2]](diffhunk://#diff-f65da199da05f3d39cdf917e1a510752d5a423aa3f954cec3787ccbd462b31e7L21-R40)
* [`.github/workflows/release-deploy.yml`](diffhunk://#diff-f65da199da05f3d39cdf917e1a510752d5a423aa3f954cec3787ccbd462b31e7L107-R124): Adjusted Docker image tagging to include the repository owner in lowercase, improving compatibility and clarity in container registry paths. [[1]](diffhunk://#diff-f65da199da05f3d39cdf917e1a510752d5a423aa3f954cec3787ccbd462b31e7L107-R124) [[2]](diffhunk://#diff-f65da199da05f3d39cdf917e1a510752d5a423aa3f954cec3787ccbd462b31e7L144-R165)

### Release Configuration Update:
* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L36-R36): Added `client/package.json` to the list of assets updated during releases, ensuring changes in the client package are included in versioning.