### PR TITLE
fix: move coverage report deployment to release workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -89,12 +89,3 @@ jobs:
         with:
           name: coverage-html
           path: ${{ github.workspace }}/coverage-report
-
-      - name: Deploy coverage to GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ github.workspace }}/coverage-report
-          destination_dir: coverage/backend
-          keep_files: true

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-and-test:
     name: Build & Test Frontend
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -78,15 +79,6 @@ jobs:
           json-summary-path: 'client/coverage/coverage-summary.json'
           json-final-path: 'client/coverage/coverage-final.json'
           vite-config-path: 'client/vitest.config.ts'
-
-      - name: Deploy coverage to GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: client/coverage
-          destination_dir: coverage/frontend
-          keep_files: true
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -82,6 +82,72 @@ jobs:
           echo "✅ New version published: ${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_STEP_SUMMARY
           echo "Release notes: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_STEP_SUMMARY
 
+  deploy-coverage:
+    name: Deploy Coverage Reports
+    needs: check-prerequisites
+    runs-on: ubuntu-latest
+    if: needs.check-prerequisites.outputs.should_deploy == 'true'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          cache: true
+          cache-dependency-path: "**/packages.lock.json"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "npm"
+          cache-dependency-path: "client/package-lock.json"
+
+      # Backend coverage
+      - name: Restore backend dependencies
+        run: dotnet restore --locked-mode
+
+      - name: Build backend
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run backend tests with coverage
+        run: dotnet test --configuration Release --no-restore --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+
+      - name: Generate backend coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
+        with:
+          reports: "**/*.cobertura.xml"
+          targetdir: "${{ github.workspace }}/coverage-report-backend"
+          reporttypes: "Html"
+
+      # Frontend coverage
+      - name: Install frontend dependencies
+        working-directory: ./client
+        run: npm ci
+
+      - name: Run frontend tests with coverage
+        working-directory: ./client
+        run: npm run test:coverage
+
+      # Deploy both coverage reports
+      - name: Deploy backend coverage to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ github.workspace }}/coverage-report-backend
+          destination_dir: coverage/backend
+          keep_files: true
+
+      - name: Deploy frontend coverage to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: client/coverage
+          destination_dir: coverage/frontend
+          keep_files: true
+
   docker-backend:
     name: Build Backend Docker Image
     needs: release

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4161,14 +4161,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/src/planora.API/planora.API.csproj
+++ b/src/planora.API/planora.API.csproj
@@ -22,4 +22,8 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Logs\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request introduces significant updates to the CI/CD workflows and minor dependency and project structure changes. The most notable changes are the consolidation of coverage deployment into a new `deploy-coverage` job in the release workflow and the removal of redundant coverage deployment steps from individual CI workflows. Additionally, a dependency update and a minor project structure adjustment were made.

### Workflow Improvements

* Removed the `Deploy coverage to GitHub Pages` steps from `backend-ci.yml` and `frontend-ci.yml` to streamline the CI workflows. [[1]](diffhunk://#diff-d30b4e6a2bd3c346243a103c773373348c1bf4a80af7bf92f854306c597fca6bL92-L100) [[2]](diffhunk://#diff-5cd76c2d3da116c3ec33f2a8ce86d739d0fe4e46c0563f2dde614ab8afc41f38L82-L90)
* Added a new `deploy-coverage` job in `release-deploy.yml` to centralize the deployment of both backend and frontend coverage reports to GitHub Pages. This includes steps for restoring dependencies, running tests, generating reports, and deploying them.
* Added `permissions: write-all` to the `frontend-ci.yml` workflow to ensure necessary permissions for the CI process.

### Dependency Updates

* Updated the `form-data` package in `client/package-lock.json` from version `4.0.2` to `4.0.4`, including a new dependency on `hasown`.

### Project Structure Adjustment

* Added a new `Logs` folder to the `.NET` project file `planora.API.csproj` for better organization of log files.